### PR TITLE
Move TaskRouter Events to be a NextGenListResource

### DIFF
--- a/lib/twilio-ruby/rest/task_router/events.rb
+++ b/lib/twilio-ruby/rest/task_router/events.rb
@@ -1,7 +1,7 @@
 module Twilio
   module REST
     module TaskRouter
-      class Events < ListResource; end
+      class Events < Twilio::REST::NextGenListResource; end
       class Event < InstanceResource; end
     end
   end


### PR DESCRIPTION
Currently, TaskRouter Events is set up as a ListResource, which breaks pagination. Inheriting from NextGenListResource fixes this behavior.